### PR TITLE
Adds support for custom feature-scenario delimiter

### DIFF
--- a/CucumberSwiftTests/CucumberTests/CucumberTests.swift
+++ b/CucumberSwiftTests/CucumberTests/CucumberTests.swift
@@ -181,4 +181,47 @@ class CucumberTests:XCTestCase {
             }
         }
     }
+
+    func testFeatureScenarioDelimiter() {
+        let featureName = "SomeTerseYetDescriptiveTextOfWhatIsDesired"
+
+        // Tests default delimiter "|"
+        CucumberTest.defaultTestSuite
+            .tests
+            .map { $0.name }
+            .filter { $0.contains(featureName) }
+            .forEach { testName in
+                XCTAssertTrue(testName.contains("\(featureName)|"), "Test name does not contain default delimiter")
+            }
+
+        // Sets custom delimiter "_"
+        Bundle.swizzleInfoDictionary()
+
+        // Tests custom delimiter "_"
+        CucumberTest.defaultTestSuite
+            .tests
+            .map { $0.name }
+            .filter { $0.contains(featureName) }
+            .forEach { testName in
+                XCTAssertFalse(testName.contains("\(featureName)|"), "Test name contains default delimiter but there should be the custom")
+                XCTAssertTrue(testName.contains("\(featureName)_"), "Test name does not contain custom delimiter")
+            }
+    }
+}
+
+private extension Bundle {
+    @objc func swizzledInfoDictionary() -> [String : Any]? {
+        return ["FeatureScenarioDelimiter": "_"]
+    }
+    /// Sets `FeatureScenarioDelimiter: "_"`
+    static func swizzleInfoDictionary() {
+        let instance = Bundle()
+        let aClass: AnyClass! = object_getClass(instance)
+        let originalMethod = class_getInstanceMethod(aClass, #selector(getter: infoDictionary))
+        let swizzledMethod = class_getInstanceMethod(aClass, #selector(swizzledInfoDictionary))
+        if let originalMethod = originalMethod, let swizzledMethod = swizzledMethod {
+            // switch implementation..
+            method_exchangeImplementations(originalMethod, swizzledMethod)
+        }
+    }
 }


### PR DESCRIPTION
Hi!
I have a problem with generated test names. If I try to upload the resulting screenshots from UI test as an artifact using [Github Action upload-artifact](https://github.com/actions/upload-artifact), it fails with error:
`Artifact path is not valid: /SmokeTests|Login/AndIAgreeWithTermsAndConditions/Screenshot_E3105048.jpg. Contains character: "|". Invalid characters include: ",:,<,>,|,*,?.`

I'm suggesting configurable delimiter to avoid these failures.

In this PR I'm adding configurable delimiter using Info.plist file (key: FeatureScenarioDelimiter).

My proposal is covered by a test that uses method swizzling for modifying of content of infoDictionary of the bundle.

P. S. Also Wiki should be updated but I don't know how to do it.