### PR TITLE
make Step.testCase public

### DIFF
--- a/CucumberSwift/Gherkin/Parser/Step.swift
+++ b/CucumberSwift/Gherkin/Parser/Step.swift
@@ -33,13 +33,13 @@ public class Step: CustomStringConvertible {
     public internal(set) var dataTable:DataTable?
     public private(set)  var docString:DocString?
     public private(set)  var location:Lexer.Position
+    public internal(set) var testCase:XCTestCase?
     
     var result:Result = .pending
     var execute:(([String], Step) -> Void)? = nil
     var executeSelector:Selector?
     var executeClass:AnyClass?
     var executeInstance:NSObject?
-    var testCase:XCTestCase?
     var regex:String = ""
     var errorMessage:String = ""
     var startTime:Date?


### PR DESCRIPTION
Motivation:
We can then attach [`addUIInterruptionMonitor`](https://developer.apple.com/documentation/xctest/xctestcase/1496273-adduiinterruptionmonitor) (directly in `Given`, `When`, `And`, `Then`) to intercept system dialogs such as Sign In using a website

<img width="273" alt="Snímek obrazovky 2020-08-04 v 17 30 13" src="https://user-images.githubusercontent.com/61665409/89313236-88eeea80-d678-11ea-8891-46e426d55d34.png">
