### PR TITLE
Groups steps into suites by scenario

### DIFF
--- a/Sources/CucumberSwift/Gherkin/Parser/ScenarioOutlineParser.swift
+++ b/Sources/CucumberSwift/Gherkin/Parser/ScenarioOutlineParser.swift
@@ -57,7 +57,7 @@ enum ScenarioOutlineParser {
             }
         }
         let tags = outlineTags
-        for line in lines.dropFirst() {
+        for (index, line) in lines.dropFirst().enumerated() {
             let title = titleLine?.reduce(into: "") {
                 if case Lexer.Token.tableHeader(_, let headerText) = $1 {
                     if let index = headerLookup?[headerText],
@@ -69,12 +69,13 @@ enum ScenarioOutlineParser {
                 } else if case Lexer.Token.title(_, let titleText) = $1 {
                     $0? += titleText
                 }
-            }
+            } ?? ""
             var steps = backgroundStepNodes.map { Step(with: $0) }
             for stepNode in stepNodes {
                 steps.append(getStepFromLine(line, lookup: headerLookup, stepNode: stepNode))
             }
-            scenarios.append(Scenario(with: steps, title: title, tags: tags, position: line.first?.position ?? .start))
+            let exampleNumber = index + 1
+            scenarios.append(Scenario(with: steps, title: "\(title) (example \(exampleNumber))", tags: tags, position: line.first?.position ?? .start))
         }
         return scenarios
     }

--- a/Tests/CucumberSwiftTests/Extensions/CucumberExtensions.swift
+++ b/Tests/CucumberSwiftTests/Extensions/CucumberExtensions.swift
@@ -27,6 +27,21 @@ extension Cucumber {
 
     func executeFeatures(callDefaultTestSuite: Bool = false) {
         if callDefaultTestSuite { _ = CucumberTest.defaultTestSuite }
-        CucumberTest.allGeneratedTests.forEach { $0.invokeTest() }
+        let suite = XCTestSuite(name: "Dummy")
+        CucumberTest.generateAlltests(suite)
+
+        var tests = [XCTestCase]()
+        Cucumber.enumerateTestsCases(&tests, suite)
+        tests.forEach { $0.invokeTest() }
+    }
+
+    private static func enumerateTestsCases(_ tests: inout [XCTestCase], _ suite: XCTestSuite) {
+        suite.tests.forEach {
+            if let testCase = $0 as? XCTestCase {
+                tests.append(testCase)
+            } else if let suite = $0 as? XCTestSuite {
+                enumerateTestsCases(&tests, suite)
+            }
+        }
     }
 }

--- a/Tests/CucumberSwiftTests/Gherkin/TableTests.swift
+++ b/Tests/CucumberSwiftTests/Gherkin/TableTests.swift
@@ -47,8 +47,8 @@ class TableTests: XCTestCase {
         XCTAssertEqual(feature?.scenarios.count, 2)
         XCTAssertEqual(firstScenario?.steps.count, 4)
         XCTAssertEqual(secondScenario?.steps.count, 4)
-        XCTAssertEqual(firstScenario?.title, "Some determinable business situation")
-        XCTAssertEqual(secondScenario?.title, "Some determinable business situation")
+        XCTAssertEqual(firstScenario?.title, "Some determinable business situation (example 1)")
+        XCTAssertEqual(secondScenario?.title, "Some determinable business situation (example 2)")
         if (firstScenario?.steps.count ?? 0) == 4 {
             let steps = firstScenario?.steps
             XCTAssertEqual(steps?[0].keyword, .given)
@@ -96,8 +96,9 @@ class TableTests: XCTestCase {
     """)
         let feature = cucumber.features.first
         XCTAssertEqual(feature?.scenarios.count, 2)
-        feature?.scenarios.forEach({ (scenario) in
-            XCTAssertEqual(scenario.title, "Some determinable business situation")
+        feature?.scenarios.enumerated().forEach({ (index, scenario) in
+            let exampleNumber = index + 1
+            XCTAssertEqual(scenario.title, "Some determinable business situation (example \(exampleNumber))")
             XCTAssertEqual(scenario.steps.count, 5)
         })
     }
@@ -126,8 +127,9 @@ class TableTests: XCTestCase {
     """)
         let feature = cucumber.features.first
         XCTAssertEqual(feature?.scenarios.count, 2)
-        feature?.scenarios.forEach({ (scenario) in
-            XCTAssertEqual(scenario.title, "Some determinable business situation")
+        feature?.scenarios.enumerated().forEach({ (index, scenario) in
+            let exampleNumber = index + 1
+            XCTAssertEqual(scenario.title, "Some determinable business situation (example \(exampleNumber))")
             XCTAssertEqual(scenario.steps.count, 5)
             XCTAssert(scenario.containsTag("outline"))
         })
@@ -146,8 +148,8 @@ class TableTests: XCTestCase {
     """)
         let firstScenario = cucumber.features.first?.scenarios.first
         let secondScenario = cucumber.features.first?.scenarios.last
-        XCTAssertEqual(firstScenario?.title, "the un")
-        XCTAssertEqual(secondScenario?.title, "the uno")
+        XCTAssertEqual(firstScenario?.title, "the un (example 1)")
+        XCTAssertEqual(secondScenario?.title, "the uno (example 2)")
     }
 
     func testTableCellWithEscapeCharacter() {
@@ -161,7 +163,7 @@ class TableTests: XCTestCase {
               | u\\|o | dos  |
     """)
         let firstScenario = cucumber.features.first?.scenarios.first
-        XCTAssertEqual(firstScenario?.title, "the u|o")
+        XCTAssertEqual(firstScenario?.title, "the u|o (example 1)")
     }
 
     func testTableGetAttachedToSteps() {


### PR DESCRIPTION
Xcode represents steps nicer in test result view.
Each scenario outline has additionally example number in title. It's necessary because otherwise Xcode merges several scenarios with the same name into single suite.

Resolves #72 