### PR TITLE
Adds function ExecuteFirstStep to run step which matches given definition

### DIFF
--- a/CucumberSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CucumberSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Tyler-Keith-Thompson/CucumberSwiftExpressions.git",
       "state" : {
-        "revision" : "d6bcc190304d5096ae64b95bd6adc7a0342f1245",
-        "version" : "0.0.7"
+        "revision" : "5200dc2c5d7cd31f07a13f030ab0027224d2dbea",
+        "version" : "0.0.8"
       }
     },
     {

--- a/Sources/CucumberSwift/Gherkin/Parser/Step.swift
+++ b/Sources/CucumberSwift/Gherkin/Parser/Step.swift
@@ -35,12 +35,15 @@ public class Step: CustomStringConvertible {
     public private(set)  var location: Lexer.Position
     public internal(set) var testCase: XCTestCase?
 
+    typealias MatchesExpression = ((_ str: String) -> Bool)
+    typealias Execute = ((_ match: String, _ steps: Step) throws -> Void)
+
     var result: Reporter.Result = .pending
-    var execute: (() throws -> Void)?
+    var execute: Execute?
     var executeSelector: Selector?
     var executeClass: AnyClass?
     var executeInstance: NSObject?
-    var regex: String = ""
+    var matchesExpression: MatchesExpression?
     var errorMessage: String = ""
     var startTime: Date?
     var endTime: Date?
@@ -99,8 +102,8 @@ public class Step: CustomStringConvertible {
     init(with execute: @escaping (([String], Step) -> Void), match: String?, position: Lexer.Position) {
         location = position
         self.match ?= match
-        self.execute = {
-            execute(self.match.matches(for: self.regex), self)
+        self.execute = { match, step in
+            execute(self.match.matches(for: ""), step)
         }
     }
 

--- a/Sources/CucumberSwift/Gherkin/Parser/Step.swift
+++ b/Sources/CucumberSwift/Gherkin/Parser/Step.swift
@@ -102,7 +102,7 @@ public class Step: CustomStringConvertible {
     init(with execute: @escaping (([String], Step) -> Void), match: String?, position: Lexer.Position) {
         location = position
         self.match ?= match
-        self.execute = { match, step in
+        self.execute = { _, step in
             execute(self.match.matches(for: ""), step)
         }
     }

--- a/Sources/CucumberSwift/Runner/Cucumber.swift
+++ b/Sources/CucumberSwift/Runner/Cucumber.swift
@@ -177,25 +177,65 @@ import CucumberSwift_ObjC
             .map { Feature(with: $0, uri: uri) })
     }
 
-    func attachClosureToSteps(keyword: Step.Keyword? = nil, regex: String, callback: @escaping (([String], Step) throws -> Void), line: Int, file: StaticString) {
+    func executeFirstStep(keyword: Step.Keyword? = nil, matching: String) {
+        let firstMatchingStep = features
+            .flatMap { $0.scenarios.flatMap { $0.steps } }
+            .first {step -> Bool in
+                if  let k = keyword,
+                    step.keyword.contains(k) {
+                    return step.matchesExpression?(matching) == true
+                } else if keyword == nil {
+                    return step.matchesExpression?(matching) == true
+                }
+                return false
+            }
+
+        if let firstMatchingStep = firstMatchingStep {
+            XCTAssertNoThrow(try firstMatchingStep.execute?(matching, firstMatchingStep))
+        } else {
+            XCTFail("No CucumberSwift expression found that matches step '\(matching)'")
+        }
+    }
+
+    private func attachClosureToSteps(keyword: Step.Keyword?,
+                                      execute: Step.Execute? = nil,
+                                      matchesExpression: @escaping Step.MatchesExpression,
+                                      line: Int,
+                                      file: StaticString,
+                                      executeSelector: Selector? = nil,
+                                      executeClass: AnyClass? = nil) {
         features
             .flatMap { $0.scenarios.flatMap { $0.steps } }
             .filter { step -> Bool in
                 if  let k = keyword,
                     step.keyword.contains(k) {
-                    return !step.match.matches(for: regex).isEmpty
+                    return matchesExpression(step.match)
                 } else if keyword == nil {
-                    return !step.match.matches(for: regex).isEmpty
+                    return matchesExpression(step.match)
                 }
                 return false
             }
             .forEach { step in
                 step.result = .undefined
-                step.execute = { try callback(step.match.matches(for: step.regex), step) }
-                step.regex = regex
+                step.execute = execute
+                step.matchesExpression = matchesExpression
                 step.sourceLine = line
                 step.sourceFile = file
+                step.executeSelector = executeSelector
+                step.executeClass = executeClass
             }
+    }
+
+    func attachClosureToSteps(keyword: Step.Keyword? = nil,
+                              regex: String,
+                              callback: @escaping (([String], Step) throws -> Void),
+                              line: Int,
+                              file: StaticString) {
+        attachClosureToSteps(keyword: keyword,
+                             execute: { match, step in try callback(match.matches(for: regex), step) },
+                             matchesExpression: { str in !str.matches(for: regex).isEmpty },
+                             line: line,
+                             file: file)
     }
 
     func attachClosureToSteps(keyword: Step.Keyword? = nil,
@@ -203,23 +243,11 @@ import CucumberSwift_ObjC
                               callback: @escaping ((CucumberSwiftExpressions.Match, Step) throws -> Void),
                               line: Int,
                               file: StaticString) {
-        features
-            .flatMap { $0.scenarios.flatMap { $0.steps } }
-            .filter { step -> Bool in
-                if  let k = keyword,
-                    step.keyword.contains(k) {
-                    return expression.match(in: step.match) != nil
-                } else if keyword == nil {
-                    return expression.match(in: step.match) != nil
-                }
-                return false
-            }
-            .forEach { step in
-                step.result = .undefined
-                step.execute = { try callback(try XCTUnwrap(expression.match(in: step.match)), step) }
-                step.sourceLine = line
-                step.sourceFile = file
-            }
+        attachClosureToSteps(keyword: keyword,
+                             execute: { match, step in try callback(try XCTUnwrap(expression.match(in: match)), step) },
+                             matchesExpression: { str in expression.match(in: str) != nil },
+                             line: line,
+                             file: file)
     }
 
 #if compiler(>=5.7) && canImport(_StringProcessing)
@@ -229,48 +257,26 @@ import CucumberSwift_ObjC
                                       callback: @escaping ((Regex<Output>.Match, Step) throws -> Void),
                                       line: Int,
                                       file: StaticString) {
-        features
-            .flatMap { $0.scenarios.flatMap { $0.steps } }
-            .filter { step -> Bool in
-                if  let k = keyword,
-                    step.keyword.contains(k) {
-                    let match = try? regex.wholeMatch(in: step.match)
-                    return match != nil
-                } else if keyword == nil {
-                    let match = try? regex.wholeMatch(in: step.match)
-                    return match != nil
-                }
-                return false
-            }
-            .forEach { step in
-                step.result = .undefined
-                step.execute = { try callback(try XCTUnwrap(regex.wholeMatch(in: step.match)), step) }
-                step.sourceLine = line
-                step.sourceFile = file
-            }
+        attachClosureToSteps(keyword: keyword,
+                             execute: { match, step in try callback(try XCTUnwrap(regex.wholeMatch(in: match)), step) },
+                             matchesExpression: { str in (try? regex.wholeMatch(in: str)) != nil },
+                             line: line,
+                             file: file)
     }
 #endif
 
-    func attachClosureToSteps(keyword: Step.Keyword? = nil, regex: String, class: AnyClass, selector: Selector, line: Int, file: StaticString) {
-        features
-            .flatMap { $0.scenarios.flatMap { $0.steps } }
-            .filter { step -> Bool in
-                if  let k = keyword,
-                    step.keyword.contains(k) {
-                    return !step.match.matches(for: regex).isEmpty
-                } else if keyword == nil {
-                    return !step.match.matches(for: regex).isEmpty
-                }
-                return false
-            }
-            .forEach { step in
-                step.result = .undefined
-                step.executeSelector = selector
-                step.executeClass = `class`
-                step.regex = regex
-                step.sourceLine = line
-                step.sourceFile = file
-            }
+    func attachClosureToSteps(keyword: Step.Keyword? = nil,
+                              regex: String,
+                              class: AnyClass,
+                              selector: Selector,
+                              line: Int,
+                              file: StaticString) {
+        attachClosureToSteps(keyword: keyword,
+                             matchesExpression: { str in !str.matches(for: regex).isEmpty },
+                             line: line,
+                             file: file,
+                             executeSelector: selector,
+                             executeClass: `class`)
     }
 }
 

--- a/Sources/CucumberSwift/Runner/CucumberTest.swift
+++ b/Sources/CucumberSwift/Runner/CucumberTest.swift
@@ -162,7 +162,7 @@ extension Step {
                     instance.perform(selector)
             }
         } else {
-            try execute?()
+            try execute?(self.match, self)
         }
         if execute != nil && result != .failed {
             result = .passed

--- a/Sources/CucumberSwift/Runner/Globals.swift
+++ b/Sources/CucumberSwift/Runner/Globals.swift
@@ -27,3 +27,7 @@ public func BeforeStep(priority: UInt? = nil, closure: @escaping ((Step) -> Void
 public func AfterStep(priority: UInt? = nil, closure: @escaping ((Step) -> Void)) {
     Cucumber.shared.afterStepHooks.append(.init(priority: priority, hook: closure))
 }
+// Execute a step matching the given step definition
+public func ExecuteFirstStep(keyword: Step.Keyword? = nil, matching: String) {
+    Cucumber.shared.executeFirstStep(keyword: keyword, matching: matching)
+}


### PR DESCRIPTION
- Adds lambda matchesExpression to Step class to match step definition with chosen matcher (CucumberExpression, string regex, regex object)

- Refactors attachClosureToSteps functions to extract common logic into single function

- Known limitation: the called step must be referred in any feature file, otherwise it's won't be found.

Resolves #66