### PR TITLE
Adds option to reverse order of After hooks

### DIFF
--- a/Sources/CucumberSwift/CucumberSwift.docc/Hooks.md
+++ b/Sources/CucumberSwift/CucumberSwift.docc/Hooks.md
@@ -48,6 +48,9 @@ extension Cucumber: StepImplementation {
 ### Execution Order
 If you never specify anything hooks will just execute in whatever order they appear in the code. However if you need specific control you can add a `priority` to hooks. The lower the priority, the earlier it executes. So a priority 1 executes before a priority 2.
 
+Other cucumber engines might have different behaviour for hooks order. For example cucumber-jvm reverses order for `@After` hooks. I.e. the earlier the priority the later `@After` hook is executed. Also `@After` hooks are executed in reverse order of registering.
+Option `reverseOrderForAfterHooks` can be overriden for `StepImplementation` and set to true to make similar behaviour.
+
 NOTE: If you do *not* specify an order hooks with no priority will execute *after* hooks with a priority
 
 ```swift
@@ -60,6 +63,9 @@ extension Cucumber: StepImplementation {
         class ThisBundle { }
         return Bundle(for: ThisBundle.self)
     }
+
+    // Uncomment if you want reverse order of 'after' hooks execution
+    // public var reverseOrderForAfterHooks: Bool { true }
 
     public func setupSteps() {
         // This hook will execute last, because it uses UInt.max as a priority

--- a/Sources/CucumberSwift/Runner/Cucumber.swift
+++ b/Sources/CucumberSwift/Runner/Cucumber.swift
@@ -18,6 +18,10 @@ import CucumberSwiftExpressions
     var reportName: String = "CucumberTestResultsFor"
     var environment: [String: String] = ProcessInfo.processInfo.environment
 
+    private var reverseOrderForAfterHooks: Bool {
+        (Cucumber.shared as? StepImplementation)?.reverseOrderForAfterHooks ?? false
+    }
+
     private var _beforeFeatureHooks = [FeatureHook]()
     var beforeFeatureHooks: [FeatureHook] {
         get {
@@ -29,7 +33,7 @@ import CucumberSwiftExpressions
     private var _afterFeatureHooks = [FeatureHook]()
     var afterFeatureHooks: [FeatureHook] {
         get {
-            _afterFeatureHooks.sorted()
+            reverseOrderForAfterHooks ? _afterFeatureHooks.sorted().reversed() : _afterFeatureHooks.sorted()
         } set {
             _afterFeatureHooks = newValue
         }
@@ -45,7 +49,7 @@ import CucumberSwiftExpressions
     private var _afterScenarioHooks = [ScenarioHook]()
     var afterScenarioHooks: [ScenarioHook] {
         get {
-            _afterScenarioHooks.sorted()
+            reverseOrderForAfterHooks ? _afterScenarioHooks.sorted().reversed() : _afterScenarioHooks.sorted()
         } set {
             _afterScenarioHooks = newValue
         }
@@ -61,7 +65,7 @@ import CucumberSwiftExpressions
     private var _afterStepHooks = [StepHook]()
     var afterStepHooks: [StepHook] {
         get {
-            _afterStepHooks.sorted()
+            reverseOrderForAfterHooks ? _afterStepHooks.sorted().reversed() : _afterStepHooks.sorted()
         } set {
             _afterStepHooks = newValue
         }

--- a/Sources/CucumberSwift/Runner/StepImplementation.swift
+++ b/Sources/CucumberSwift/Runner/StepImplementation.swift
@@ -15,4 +15,5 @@ import Foundation
     @objc optional func shouldRunWith(tags: [String]) -> Bool
     @objc optional func shouldRunWith(scenario: Scenario?, tags: [String]) -> Bool
     @objc optional var continueTestingAfterFailure: Bool { get }
+    @objc optional var reverseOrderForAfterHooks: Bool { get }
 }

--- a/Tests/CucumberSwiftTests/CucumberSwiftTests.swift
+++ b/Tests/CucumberSwiftTests/CucumberSwiftTests.swift
@@ -490,4 +490,7 @@ extension Cucumber: StepImplementation {
     public func shouldRunWith(scenario: Scenario?, tags: [String]) -> Bool {
         Cucumber.shouldRunWith(scenario, tags)
     }
+
+    public static var overrideReverseOrderForAfterHooks = false
+    public var reverseOrderForAfterHooks: Bool { Cucumber.overrideReverseOrderForAfterHooks }
 }

--- a/Tests/CucumberSwiftTests/Runner/HookTests.swift
+++ b/Tests/CucumberSwiftTests/Runner/HookTests.swift
@@ -19,6 +19,7 @@ class HookTests: XCTestCase {
 
     override func tearDownWithError() throws {
         Cucumber.shared.reset()
+        Cucumber.overrideReverseOrderForAfterHooks = false
     }
 
     func testBeforeFeatureHookTriggersAppropriately() {
@@ -431,6 +432,121 @@ class HookTests: XCTestCase {
         ])
     }
 
+    func testMultipleBeforeAndAfterHooksTriggerAppropriately_Reversed() {
+        Cucumber.overrideReverseOrderForAfterHooks = true
+        Cucumber.shared.parseIntoFeatures("""
+        Feature: Some terse yet descriptive text of what is desired
+           Scenario: Some determinable business situation
+             Given some precondition
+             When some action is performed
+             Then some testable result is achieved
+
+            Scenario: Some other determinable business situation
+              Given some other precondition
+              When some action is performed
+              Then some testable result is achieved
+        """)
+
+        var executionOrder = [String]()
+        BeforeFeature { feature in
+            executionOrder.append("BeforeFeature")
+            XCTAssertEqual(feature.title, "Some terse yet descriptive text of what is desired")
+        }
+
+        BeforeFeature { feature in
+            executionOrder.append("BeforeFeature2")
+            XCTAssertEqual(feature.title, "Some terse yet descriptive text of what is desired")
+        }
+
+        AfterFeature { feature in
+            executionOrder.append("AfterFeature")
+            XCTAssertEqual(feature.title, "Some terse yet descriptive text of what is desired")
+        }
+
+        AfterFeature { feature in
+            executionOrder.append("AfterFeature2")
+            XCTAssertEqual(feature.title, "Some terse yet descriptive text of what is desired")
+        }
+
+        BeforeScenario { scenario in
+            executionOrder.append("BeforeScenario_\(scenario.title)")
+        }
+
+        BeforeScenario { scenario in
+            executionOrder.append("BeforeScenario2_\(scenario.title)")
+        }
+
+        AfterScenario { scenario in
+            executionOrder.append("AfterScenario_\(scenario.title)")
+        }
+
+        AfterScenario { scenario in
+            executionOrder.append("AfterScenario2_\(scenario.title)")
+        }
+
+        BeforeStep { step in
+            executionOrder.append("BeforeStep_\(step.match)")
+        }
+
+        BeforeStep { step in
+            executionOrder.append("BeforeStep2_\(step.match)")
+        }
+
+        AfterStep { step in
+            executionOrder.append("AfterStep_\(step.match)")
+        }
+
+        AfterStep { step in
+            executionOrder.append("AfterStep2_\(step.match)")
+        }
+
+        Given("some precondition") { _, _ in executionOrder.append("Given some precondition") }
+        Given("some other precondition") { _, _ in executionOrder.append("Given some other precondition") }
+
+        Cucumber.shared.executeFeatures()
+
+        XCTAssertEqual(executionOrder, [
+            "BeforeFeature",
+            "BeforeFeature2",
+            "BeforeScenario_Some determinable business situation",
+            "BeforeScenario2_Some determinable business situation",
+            "BeforeStep_some precondition",
+            "BeforeStep2_some precondition",
+            "Given some precondition",
+            "AfterStep2_some precondition",
+            "AfterStep_some precondition",
+            "BeforeStep_some action is performed",
+            "BeforeStep2_some action is performed",
+            "AfterStep2_some action is performed",
+            "AfterStep_some action is performed",
+            "BeforeStep_some testable result is achieved",
+            "BeforeStep2_some testable result is achieved",
+            "AfterStep2_some testable result is achieved",
+            "AfterStep_some testable result is achieved",
+            "AfterScenario2_Some determinable business situation",
+            "AfterScenario_Some determinable business situation",
+            "BeforeScenario_Some other determinable business situation",
+            "BeforeScenario2_Some other determinable business situation",
+            "BeforeStep_some other precondition",
+            "BeforeStep2_some other precondition",
+            "Given some other precondition",
+            "AfterStep2_some other precondition",
+            "AfterStep_some other precondition",
+            "BeforeStep_some action is performed",
+            "BeforeStep2_some action is performed",
+            "AfterStep2_some action is performed",
+            "AfterStep_some action is performed",
+            "BeforeStep_some testable result is achieved",
+            "BeforeStep2_some testable result is achieved",
+            "AfterStep2_some testable result is achieved",
+            "AfterStep_some testable result is achieved",
+            "AfterScenario2_Some other determinable business situation",
+            "AfterScenario_Some other determinable business situation",
+            "AfterFeature2",
+            "AfterFeature"
+        ])
+    }
+
     func testMultipleBeforeAndAfterHooks_ThatDefineTheirOwnOrder_TriggerAppropriately() {
         Cucumber.shared.parseIntoFeatures("""
         Feature: Some terse yet descriptive text of what is desired
@@ -543,6 +659,122 @@ class HookTests: XCTestCase {
             "AfterScenario2_Some other determinable business situation",
             "AfterFeature",
             "AfterFeature2"
+        ])
+    }
+
+    func testMultipleBeforeAndAfterHooks_ThatDefineTheirOwnOrder_TriggerAppropriately_Reversed() {
+        Cucumber.overrideReverseOrderForAfterHooks = true
+        Cucumber.shared.parseIntoFeatures("""
+        Feature: Some terse yet descriptive text of what is desired
+           Scenario: Some determinable business situation
+             Given some precondition
+             When some action is performed
+             Then some testable result is achieved
+
+            Scenario: Some other determinable business situation
+              Given some other precondition
+              When some action is performed
+              Then some testable result is achieved
+        """)
+
+        var executionOrder = [String]()
+
+        BeforeFeature(priority: .max) { feature in
+            executionOrder.append("BeforeFeature2")
+            XCTAssertEqual(feature.title, "Some terse yet descriptive text of what is desired")
+        }
+
+        BeforeFeature(priority: 1) { feature in
+            executionOrder.append("BeforeFeature")
+            XCTAssertEqual(feature.title, "Some terse yet descriptive text of what is desired")
+        }
+
+        AfterFeature(priority: .max) { feature in
+            executionOrder.append("AfterFeature2")
+            XCTAssertEqual(feature.title, "Some terse yet descriptive text of what is desired")
+        }
+
+        AfterFeature(priority: 1) { feature in
+            executionOrder.append("AfterFeature")
+            XCTAssertEqual(feature.title, "Some terse yet descriptive text of what is desired")
+        }
+
+        BeforeScenario(priority: .max) { scenario in
+            executionOrder.append("BeforeScenario2_\(scenario.title)")
+        }
+
+        BeforeScenario(priority: 1) { scenario in
+            executionOrder.append("BeforeScenario_\(scenario.title)")
+        }
+
+        AfterScenario(priority: .max) { scenario in
+            executionOrder.append("AfterScenario2_\(scenario.title)")
+        }
+
+        AfterScenario(priority: 1) { scenario in
+            executionOrder.append("AfterScenario_\(scenario.title)")
+        }
+
+        BeforeStep(priority: .max) { step in
+            executionOrder.append("BeforeStep2_\(step.match)")
+        }
+
+        BeforeStep(priority: 1) { step in
+            executionOrder.append("BeforeStep_\(step.match)")
+        }
+
+        AfterStep(priority: .max) { step in
+            executionOrder.append("AfterStep2_\(step.match)")
+        }
+
+        AfterStep(priority: 1) { step in
+            executionOrder.append("AfterStep_\(step.match)")
+        }
+
+        Given("some precondition") { _, _ in executionOrder.append("Given some precondition") }
+        Given("some other precondition") { _, _ in executionOrder.append("Given some other precondition") }
+
+        Cucumber.shared.executeFeatures()
+
+        XCTAssertEqual(executionOrder, [
+            "BeforeFeature",
+            "BeforeFeature2",
+            "BeforeScenario_Some determinable business situation",
+            "BeforeScenario2_Some determinable business situation",
+            "BeforeStep_some precondition",
+            "BeforeStep2_some precondition",
+            "Given some precondition",
+            "AfterStep2_some precondition",
+            "AfterStep_some precondition",
+            "BeforeStep_some action is performed",
+            "BeforeStep2_some action is performed",
+            "AfterStep2_some action is performed",
+            "AfterStep_some action is performed",
+            "BeforeStep_some testable result is achieved",
+            "BeforeStep2_some testable result is achieved",
+            "AfterStep2_some testable result is achieved",
+            "AfterStep_some testable result is achieved",
+            "AfterScenario2_Some determinable business situation",
+            "AfterScenario_Some determinable business situation",
+            "BeforeScenario_Some other determinable business situation",
+            "BeforeScenario2_Some other determinable business situation",
+            "BeforeStep_some other precondition",
+            "BeforeStep2_some other precondition",
+            "Given some other precondition",
+            "AfterStep2_some other precondition",
+            "AfterStep_some other precondition",
+            "BeforeStep_some action is performed",
+            "BeforeStep2_some action is performed",
+            "AfterStep2_some action is performed",
+            "AfterStep_some action is performed",
+            "BeforeStep_some testable result is achieved",
+            "BeforeStep2_some testable result is achieved",
+            "AfterStep2_some testable result is achieved",
+            "AfterStep_some testable result is achieved",
+            "AfterScenario2_Some other determinable business situation",
+            "AfterScenario_Some other determinable business situation",
+            "AfterFeature2",
+            "AfterFeature"
         ])
     }
 


### PR DESCRIPTION
Option reverseOrderForAfterHooks in StepImplementation enables cucumber-jvm - like behavior when 'order' number and order of "After" hooks registration has reverse meaning.

Solves: #80