### PR TITLE
Exposing a rawLiteral on DocString for situation where sanitization is too eager

### DIFF
--- a/Sources/CucumberSwift/Gherkin/Parser/DocString.swift
+++ b/Sources/CucumberSwift/Gherkin/Parser/DocString.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 public struct DocString: Hashable {
+    public let rawLiteral: String
     public var literal: String
     public var contentType: String?
 }

--- a/Tests/CucumberSwiftTests/Gherkin/DocstringTests.swift
+++ b/Tests/CucumberSwiftTests/Gherkin/DocstringTests.swift
@@ -162,4 +162,30 @@ class DocstringTests: XCTestCase {
         third line
         """)
     }
+
+    func testDocStringPreservesEscapedQuotesWithinJSONString() throws {
+        let cucumber = Cucumber(withString:
+            #"""
+            Feature: DocString variations
+
+            Scenario: minimalistic
+                Given a DocString with JSON with escaped quotes in a string
+                """
+                {
+                    "stringWithEscapedQuote":"String with a \"quote\" or two"
+                }
+                """
+            """#
+        )
+        let firstStep = cucumber.features.first?.scenarios.first?.steps.first
+        let jsonString = try XCTUnwrap(firstStep?.docString?.rawLiteral)
+        let jsonData = try XCTUnwrap(jsonString.data(using: .utf8))
+
+        struct MyJsonType: Decodable {
+            let stringWithEscapedQuote: String
+        }
+
+        let jsonObject = try JSONDecoder().decode(MyJsonType.self, from: jsonData)
+        XCTAssertEqual(jsonObject.stringWithEscapedQuote, "String with a \"quote\" or two")
+    }
 }


### PR DESCRIPTION
In our project we have a situation where some Gherkin steps simulate JSON responses.
These JSON response are added to steps in form of a DocString.

Unfortunately, if a JSON string property contains an escaped quote character, then `step?.docString?.literal` strips it away; E.g.:
`"String with a \"quote\" or two"`
becomes
`"String with a "quote" or two"`
Which is no longer valid JSON.

I couldn't find an easy solution to fix the escaping, or why it was removed to begin with.
But since there are tests explicitly defining the current behavior, I instead I added a `rawLiteral` property to the `DocString` struct.

Please have a look at the added unit test for clarification.