### PR TITLE
fix: resolve tests running twice

### DIFF
--- a/Sources/CucumberSwift/Runner/CucumberTest.swift
+++ b/Sources/CucumberSwift/Runner/CucumberTest.swift
@@ -16,13 +16,14 @@ open class CucumberTest: XCTestCase {
     private static var suiteInstance: XCTestSuite?
 
     override open func invokeTest() {
-        guard !Self.didRun else { return }
+        guard !Self.didRun else {
+            return
+        }
         Self.didRun = true
         super.invokeTest()
     }
 
     override public class var defaultTestSuite: XCTestSuite {
-
         // notify reporters every time
         Cucumber.shared.reporters.forEach { $0.testSuiteStarted(at: Date()) }
 

--- a/Sources/CucumberSwift/Runner/CucumberTest.swift
+++ b/Sources/CucumberSwift/Runner/CucumberTest.swift
@@ -10,10 +10,29 @@ import Foundation
 import XCTest
 
 open class CucumberTest: XCTestCase {
+
+    static var didRun = false
+
+    private static var suiteInstance: XCTestSuite?
+
+    override open func invokeTest() {
+        guard !Self.didRun else { return }
+        Self.didRun = true
+        super.invokeTest()
+    }
+
     override public class var defaultTestSuite: XCTestSuite {
+
+        // notify reporters every time
         Cucumber.shared.reporters.forEach { $0.testSuiteStarted(at: Date()) }
 
+        // create default test suite only once
+        if let existingSuite = suiteInstance {
+            return existingSuite
+        }
+
         let suite = XCTestSuite(forTestCaseClass: CucumberTest.self)
+        suiteInstance = suite
 
         Cucumber.shared.features.removeAll()
         if let bundle = (Cucumber.shared as? StepImplementation)?.bundle {

--- a/Sources/CucumberSwift/Runner/CucumberTest.swift
+++ b/Sources/CucumberSwift/Runner/CucumberTest.swift
@@ -10,18 +10,9 @@ import Foundation
 import XCTest
 
 open class CucumberTest: XCTestCase {
-
     static var didRun = false
 
     private static var suiteInstance: XCTestSuite?
-
-    override open func invokeTest() {
-        guard !Self.didRun else {
-            return
-        }
-        Self.didRun = true
-        super.invokeTest()
-    }
 
     override public class var defaultTestSuite: XCTestSuite {
         // notify reporters every time
@@ -43,6 +34,14 @@ open class CucumberTest: XCTestCase {
         assert(!Cucumber.shared.features.isEmpty, "CucumberSwift found no features to run. Check out our documentation for instructions on including you Features folder. Be aware it's a case sensitive search. If you're using the DSL, make sure your features are defined in the `setupSteps()` method.") // swiftlint:disable:this line_length
         generateAlltests(suite)
         return suite
+    }
+
+    override open func invokeTest() {
+        guard !Self.didRun else {
+            return
+        }
+        Self.didRun = true
+        super.invokeTest()
     }
 
     static func generateAlltests(_ rootSuite: XCTestSuite) {

--- a/Sources/CucumberSwift/Runner/CucumberTest.swift
+++ b/Sources/CucumberSwift/Runner/CucumberTest.swift
@@ -36,14 +36,6 @@ open class CucumberTest: XCTestCase {
         return suite
     }
 
-    override open func invokeTest() {
-        guard !Self.didRun else {
-            return
-        }
-        Self.didRun = true
-        super.invokeTest()
-    }
-
     static func generateAlltests(_ rootSuite: XCTestSuite) {
         let stubsSuite = XCTestSuite(name: "GeneratedSteps")
         var stubTests = [XCTestCase]()
@@ -111,6 +103,14 @@ open class CucumberTest: XCTestCase {
                 testCase.continueAfterFailure = step.continueAfterFailure
                 tests.append(testCase)
             }
+    }
+
+    override open func invokeTest() {
+        guard !Self.didRun else {
+            return
+        }
+        Self.didRun = true
+        super.invokeTest()
     }
 
     // A test case needs at least one test to trigger the observer

--- a/Tests/CucumberSwiftTests/Reporter/CustomReporterTests.swift
+++ b/Tests/CucumberSwiftTests/Reporter/CustomReporterTests.swift
@@ -113,6 +113,16 @@ class CustomReporterTests: XCTestCase {
         Cucumber.shared.reset()
     }
 
+    func testDefaultSuiteIsCreatedOnlyOnce() {
+        Cucumber.shared.parseIntoFeatures(featureFile)
+        let defaultSuiteBefore = CucumberTest.defaultTestSuite
+
+        Cucumber.shared.executeFeatures(callDefaultTestSuite: true)
+
+        let defaultSuiteAfter = CucumberTest.defaultTestSuite
+        XCTAssertEqual(defaultSuiteBefore, defaultSuiteAfter)
+    }
+
     func testReporterIsToldWhenTestSuiteStarts() {
         Cucumber.shared.parseIntoFeatures(featureFile)
         var called = 0


### PR DESCRIPTION
PR for #88.

This pull request primarily focuses on improving the execution of the test suite in the `CucumberSwift` project. The changes ensure that the default test suite is created only once and that tests are invoked only if they haven't run before. Additionally, a new test case has been added to verify this behavior.

Changes made:

* [`Sources/CucumberSwift/Runner/CucumberTest.swift`](diffhunk://#diff-f8fcb9c6246f3c7836d008a7379a8d62812993d9765dc5f3004f3a205b257990R13-R35): Implemented a mechanism to ensure that the default test suite is created only once and that tests are invoked only if they haven't run before. This was achieved by introducing a static boolean `didRun` and a static `XCTestSuite` instance `suiteInstance`. `didRun` is checked before invoking a test and `suiteInstance` is checked before creating a new test suite. If `suiteInstance` already exists, it is returned instead of creating a new one.

* [`Tests/CucumberSwiftTests/Reporter/CustomReporterTests.swift`](diffhunk://#diff-f699526698d34eca841448f6dff0d63c12a934ae137aeb5f2461ce379b954c9aR116-R125): Added a new test case `testDefaultSuiteIsCreatedOnlyOnce` to verify that the default test suite is indeed created only once. This test case runs a feature file, captures the default test suite before and after execution, and asserts that they are equal.