### PR TITLE
Fix scenarios with identical names across feature files being merged

### DIFF
--- a/Sources/CucumberSwift/Runner/CucumberTest.swift
+++ b/Sources/CucumberSwift/Runner/CucumberTest.swift
@@ -12,7 +12,13 @@ import XCTest
 open class CucumberTest: XCTestCase {
     static var didRun = false
 
-    static var suiteInstance: XCTestSuite?
+    private static var suiteInstance: XCTestSuite?
+
+    #if DEBUG
+    static func resetSuiteCache() {
+        suiteInstance = nil
+    }
+    #endif
 
     override public class var defaultTestSuite: XCTestSuite {
         // notify reporters every time

--- a/Sources/CucumberSwift/Runner/CucumberTest.swift
+++ b/Sources/CucumberSwift/Runner/CucumberTest.swift
@@ -47,7 +47,7 @@ open class CucumberTest: XCTestCase {
             let className = feature.title.toClassString() + readFeatureScenarioDelimiter()
 
             for scenario in feature.scenarios.taggedElements(with: Cucumber.shared.environment, askImplementor: true) {
-                let childSuite = XCTestSuite(name: scenario.title.toClassString())
+                let childSuite = XCTestSuite(name: className + scenario.title.toClassString())
                 var tests = [XCTestCase]()
                 createTestCaseFor(className: className, scenario: scenario, tests: &tests)
                 tests.forEach { childSuite.addTest($0) }

--- a/Sources/CucumberSwift/Runner/CucumberTest.swift
+++ b/Sources/CucumberSwift/Runner/CucumberTest.swift
@@ -12,7 +12,7 @@ import XCTest
 open class CucumberTest: XCTestCase {
     static var didRun = false
 
-    private static var suiteInstance: XCTestSuite?
+    static var suiteInstance: XCTestSuite?
 
     override public class var defaultTestSuite: XCTestSuite {
         // notify reporters every time

--- a/Tests/CucumberSwiftTests/CucumberTests/CucumberTests.swift
+++ b/Tests/CucumberSwiftTests/CucumberTests/CucumberTests.swift
@@ -211,7 +211,9 @@ class CucumberTests: XCTestCase {
         let featureName = "SomeTerseYetDescriptiveTextOfWhatIsDesired"
 
         // Tests default delimiter "|"
-        CucumberTest.defaultTestSuite
+        let defaultSuite = XCTestSuite(name: "DefaultDelimiterTests")
+        CucumberTest.generateAlltests(defaultSuite)
+        defaultSuite
             .tests
             .map { $0.name }
             .filter { $0.contains(featureName) }
@@ -223,7 +225,9 @@ class CucumberTests: XCTestCase {
         Bundle.swizzleInfoDictionary()
 
         // Tests custom delimiter "_"
-        CucumberTest.defaultTestSuite
+        let customSuite = XCTestSuite(name: "CustomDelimiterTests")
+        CucumberTest.generateAlltests(customSuite)
+        customSuite
             .tests
             .map { $0.name }
             .filter { $0.contains(featureName) }

--- a/Tests/CucumberSwiftTests/CucumberTests/CucumberTests.swift
+++ b/Tests/CucumberSwiftTests/CucumberTests/CucumberTests.swift
@@ -211,8 +211,9 @@ class CucumberTests: XCTestCase {
         let featureName = "SomeTerseYetDescriptiveTextOfWhatIsDesired"
 
         // Tests default delimiter "|"
-        let defaultSuite = XCTestSuite(name: "DefaultDelimiterTests")
-        CucumberTest.generateAlltests(defaultSuite)
+        CucumberTest.suiteInstance = nil
+        let defaultSuite = CucumberTest.defaultTestSuite
+        XCTAssertTrue(CucumberTest.defaultTestSuite === defaultSuite, "Suite should be cached on repeated calls")
         defaultSuite
             .tests
             .map { $0.name }
@@ -225,9 +226,8 @@ class CucumberTests: XCTestCase {
         Bundle.swizzleInfoDictionary()
 
         // Tests custom delimiter "_"
-        let customSuite = XCTestSuite(name: "CustomDelimiterTests")
-        CucumberTest.generateAlltests(customSuite)
-        customSuite
+        CucumberTest.suiteInstance = nil
+        CucumberTest.defaultTestSuite
             .tests
             .map { $0.name }
             .filter { $0.contains(featureName) }

--- a/Tests/CucumberSwiftTests/CucumberTests/CucumberTests.swift
+++ b/Tests/CucumberSwiftTests/CucumberTests/CucumberTests.swift
@@ -211,7 +211,7 @@ class CucumberTests: XCTestCase {
         let featureName = "SomeTerseYetDescriptiveTextOfWhatIsDesired"
 
         // Tests default delimiter "|"
-        CucumberTest.suiteInstance = nil
+        CucumberTest.resetSuiteCache()
         let defaultSuite = CucumberTest.defaultTestSuite
         XCTAssertTrue(CucumberTest.defaultTestSuite === defaultSuite, "Suite should be cached on repeated calls")
         defaultSuite
@@ -226,7 +226,7 @@ class CucumberTests: XCTestCase {
         Bundle.swizzleInfoDictionary()
 
         // Tests custom delimiter "_"
-        CucumberTest.suiteInstance = nil
+        CucumberTest.resetSuiteCache()
         CucumberTest.defaultTestSuite
             .tests
             .map { $0.name }


### PR DESCRIPTION
When multiple feature files contain scenarios with the same title (e.g., "Scenario A" in both feature_a.feature and feature_b.feature), CucumberSwift generates XCTestSuites with identical names. XCTest merges these suites, causing steps from different scenarios to be concatenated into a single test run.

This leads to:
- Steps appearing as duplicates and being silently skipped
- Gherkin "duplicate step" errors
- Cascading test failures from skipped steps
- Incorrect test results that are difficult to diagnose

The fix prepends the feature title (already available as `className`) to the XCTestSuite name, ensuring each scenario gets a unique suite name scoped by its feature file. This matches the behavior of other Cucumber implementations where scenario names are scoped per feature.

Before: XCTestSuite(name: "SaveFromDiscardDialog")
After:  XCTestSuite(name: "DailyDiaryEntry|SaveFromDiscardDialog")