### PR TITLE
fix: invalidate cache when test already ran

### DIFF
--- a/Sources/CucumberSwift/Runner/CucumberTest.swift
+++ b/Sources/CucumberSwift/Runner/CucumberTest.swift
@@ -24,8 +24,8 @@ open class CucumberTest: XCTestCase {
         // notify reporters every time
         Cucumber.shared.reporters.forEach { $0.testSuiteStarted(at: Date()) }
 
-        // create default test suite only once
-        if let existingSuite = suiteInstance {
+        // return cached suite only if its test run hasn't already completed
+        if let existingSuite = suiteInstance, existingSuite.testRun?.stopDate == nil {
             return existingSuite
         }
 

--- a/Sources/CucumberSwift/Runner/CucumberTest.swift
+++ b/Sources/CucumberSwift/Runner/CucumberTest.swift
@@ -12,25 +12,25 @@ import XCTest
 open class CucumberTest: XCTestCase {
     static var didRun = false
 
-    private static var suiteInstance: XCTestSuite?
+    private static var hasBeenBuilt = false
 
     #if DEBUG
-    static func resetSuiteCache() {
-        suiteInstance = nil
+    static func resetSetUp() {
+        hasBeenBuilt = false
     }
     #endif
 
     override public class var defaultTestSuite: XCTestSuite {
-        // notify reporters every time
         Cucumber.shared.reporters.forEach { $0.testSuiteStarted(at: Date()) }
 
-        // return cached suite only if its test run hasn't already completed
-        if let existingSuite = suiteInstance, existingSuite.testRun?.stopDate == nil {
-            return existingSuite
+        // XCTest discovers CucumberTest in both the test bundle and the framework,
+        // calling defaultTestSuite for each. Only the first call should return a
+        // populated suite. Subsequent calls return an empty suite to prevent double
+        // execution of scenarios and hooks, and to avoid "Invalid attempt to start
+        // a test run that has already been started".
+        guard !hasBeenBuilt else {
+            return XCTestSuite(name: String(describing: CucumberTest.self))
         }
-
-        let suite = XCTestSuite(forTestCaseClass: CucumberTest.self)
-        suiteInstance = suite
 
         Cucumber.shared.features.removeAll()
         if let bundle = (Cucumber.shared as? StepImplementation)?.bundle {
@@ -38,7 +38,10 @@ open class CucumberTest: XCTestCase {
         }
         (Cucumber.shared as? StepImplementation)?.setupSteps()
         assert(!Cucumber.shared.features.isEmpty, "CucumberSwift found no features to run. Check out our documentation for instructions on including you Features folder. Be aware it's a case sensitive search. If you're using the DSL, make sure your features are defined in the `setupSteps()` method.") // swiftlint:disable:this line_length
+
+        let suite = XCTestSuite(forTestCaseClass: CucumberTest.self)
         generateAlltests(suite)
+        hasBeenBuilt = true
         return suite
     }
 

--- a/Tests/CucumberSwiftConsumerTests/CucumberSwiftConsumerTests.swift
+++ b/Tests/CucumberSwiftConsumerTests/CucumberSwiftConsumerTests.swift
@@ -57,6 +57,21 @@ extension CucumberTest {
     }
 }
 
+// Z prefix ensures this runs after XCTest has already executed the CucumberTest suite
+class ZCucumberTestCacheTests: XCTestCase {
+    func testDefaultTestSuiteReturnsEmptyOnSubsequentCalls() {
+        // First call builds the full suite. Second call must return an empty suite
+        // to prevent XCTest from running CucumberTest twice when discovered in both
+        // the test bundle and framework, avoiding "Invalid attempt to start a test
+        // run that has already been started".
+        let firstSuite = CucumberTest.defaultTestSuite
+        let secondSuite = CucumberTest.defaultTestSuite
+        XCTAssertFalse(firstSuite === secondSuite)
+        XCTAssertTrue(secondSuite.tests.isEmpty,
+                      "Second call should return an empty suite")
+    }
+}
+
 extension Cucumber: StepImplementation {
     public var bundle: Bundle {
         class TestDiscovery: CucumberTest { }

--- a/Tests/CucumberSwiftTests/CucumberTests/CucumberTests.swift
+++ b/Tests/CucumberSwiftTests/CucumberTests/CucumberTests.swift
@@ -207,6 +207,21 @@ class CucumberTests: XCTestCase {
         }
     }
 
+    func testDefaultTestSuiteInvalidatesCacheAfterSuiteHasRun() {
+        CucumberTest.resetSuiteCache()
+        let firstSuite = CucumberTest.defaultTestSuite
+
+        // Actually run the suite so XCTest sets its testRun with start/stop dates
+        firstSuite.run()
+        XCTAssertNotNil(firstSuite.testRun?.stopDate, "Suite should have a completed test run")
+
+        // After the suite has been run, requesting defaultTestSuite again
+        // should return a NEW suite, not the stale one whose testRun already completed
+        let secondSuite = CucumberTest.defaultTestSuite
+        XCTAssertFalse(firstSuite === secondSuite,
+                        "defaultTestSuite must not return a suite whose test run has already completed")
+    }
+
     func testFeatureScenarioDelimiter() {
         let featureName = "SomeTerseYetDescriptiveTextOfWhatIsDesired"
 

--- a/Tests/CucumberSwiftTests/CucumberTests/CucumberTests.swift
+++ b/Tests/CucumberSwiftTests/CucumberTests/CucumberTests.swift
@@ -207,29 +207,12 @@ class CucumberTests: XCTestCase {
         }
     }
 
-    func testDefaultTestSuiteInvalidatesCacheAfterSuiteHasRun() {
-        CucumberTest.resetSuiteCache()
-        let firstSuite = CucumberTest.defaultTestSuite
-
-        // Actually run the suite so XCTest sets its testRun with start/stop dates
-        firstSuite.run()
-        XCTAssertNotNil(firstSuite.testRun?.stopDate, "Suite should have a completed test run")
-
-        // After the suite has been run, requesting defaultTestSuite again
-        // should return a NEW suite, not the stale one whose testRun already completed
-        let secondSuite = CucumberTest.defaultTestSuite
-        XCTAssertFalse(firstSuite === secondSuite,
-                        "defaultTestSuite must not return a suite whose test run has already completed")
-    }
-
     func testFeatureScenarioDelimiter() {
         let featureName = "SomeTerseYetDescriptiveTextOfWhatIsDesired"
 
         // Tests default delimiter "|"
-        CucumberTest.resetSuiteCache()
-        let defaultSuite = CucumberTest.defaultTestSuite
-        XCTAssertTrue(CucumberTest.defaultTestSuite === defaultSuite, "Suite should be cached on repeated calls")
-        defaultSuite
+        CucumberTest.resetSetUp()
+        CucumberTest.defaultTestSuite
             .tests
             .map { $0.name }
             .filter { $0.contains(featureName) }
@@ -241,7 +224,7 @@ class CucumberTests: XCTestCase {
         Bundle.swizzleInfoDictionary()
 
         // Tests custom delimiter "_"
-        CucumberTest.resetSuiteCache()
+        CucumberTest.resetSetUp()
         CucumberTest.defaultTestSuite
             .tests
             .map { $0.name }

--- a/Tests/CucumberSwiftTests/Reporter/CustomReporterTests.swift
+++ b/Tests/CucumberSwiftTests/Reporter/CustomReporterTests.swift
@@ -113,14 +113,16 @@ class CustomReporterTests: XCTestCase {
         Cucumber.shared.reset()
     }
 
-    func testDefaultSuiteIsCreatedOnlyOnce() {
+    func testDefaultSuiteReturnsEmptyOnSecondCall() {
         Cucumber.shared.parseIntoFeatures(featureFile)
-        let defaultSuiteBefore = CucumberTest.defaultTestSuite
+        CucumberTest.resetSetUp()
+        let firstSuite = CucumberTest.defaultTestSuite
 
-        Cucumber.shared.executeFeatures(callDefaultTestSuite: true)
-
-        let defaultSuiteAfter = CucumberTest.defaultTestSuite
-        XCTAssertEqual(defaultSuiteBefore, defaultSuiteAfter)
+        // Second call returns empty suite to prevent XCTest from running
+        // CucumberTest twice when discovered in both test bundle and framework
+        let secondSuite = CucumberTest.defaultTestSuite
+        XCTAssertFalse(firstSuite.tests.isEmpty, "First call should return a populated suite")
+        XCTAssertTrue(secondSuite.tests.isEmpty, "Second call should return an empty suite")
     }
 
     func testReporterIsToldWhenTestSuiteStarts() {


### PR DESCRIPTION
This pull request updates the logic for building the default test suite in `CucumberTest` to prevent duplicate execution of tests when XCTest discovers the test case in both the test bundle and the framework. The changes ensure that only the first call to `defaultTestSuite` returns a populated suite, while subsequent calls return an empty suite, thus avoiding errors and double execution. The PR also updates related tests and renames/reset methods for clarity.

**Test suite construction and caching:**

* Changed `CucumberTest` to use a `hasBeenBuilt` flag instead of caching the suite instance, ensuring that only the first call to `defaultTestSuite` returns a populated suite and subsequent calls return an empty suite to avoid double execution and XCTest errors.
* Renamed the reset method from `resetSuiteCache()` to `resetSetUp()` and updated all usages for clarity and correctness. [[1]](diffhunk://#diff-f8fcb9c6246f3c7836d008a7379a8d62812993d9765dc5f3004f3a205b257990L15-R44) [[2]](diffhunk://#diff-d4c0ca504896a3c131f509dd313523b16efd1c8cdc019cbab66d38e82ee87b66L214-R215) [[3]](diffhunk://#diff-d4c0ca504896a3c131f509dd313523b16efd1c8cdc019cbab66d38e82ee87b66L229-R227)

**Test updates and coverage:**

* Updated and added tests to verify that the first call to `CucumberTest.defaultTestSuite` returns a populated suite and subsequent calls return an empty suite, both in consumer and reporter test targets. [[1]](diffhunk://#diff-12f9ba379b170b28aec9c834ade8bb36b3836a7b6a7387cd4b4f33454f2ebad2R60-R74) [[2]](diffhunk://#diff-f699526698d34eca841448f6dff0d63c12a934ae137aeb5f2461ce379b954c9aL116-R125)
* Updated test names and assertions to reflect the new suite-building behavior, ensuring the tests accurately check for empty/non-empty suites on subsequent calls.

These changes improve the reliability of test execution and prevent issues with duplicate test runs in environments where XCTest discovers the same test class in multiple locations.

[Summary generated by Copilot]